### PR TITLE
Change monitoring reader to resource group level

### DIFF
--- a/components/infra/roles.tf
+++ b/components/infra/roles.tf
@@ -1,6 +1,6 @@
 resource "azurerm_role_assignment" "monitoring_reader" {
   for_each             = local.business_area == "cft" ? toset(local.cft_subscriptions) : toset(local.sds_subscriptions)
-  scope                = azurerm_monitor_action_group.action_group.id
+  scope                = azurerm_resource_group.this.id
   role_definition_name = "Monitoring Reader"
   principal_id         = data.azuread_service_principal.bootstrap[each.value].object_id
   principal_type       = "ServicePrincipal"


### PR DESCRIPTION
### Change description

Receiving errors in the cft-jenkins-infrastructure pipeline still because the reader role needs to be at the resource group level rather than the action group itself
This doesn't really change the permission level much and it's still read only access

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
